### PR TITLE
CAD and other stuffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,15 +316,14 @@ I got inspiration from the countless awesome lists in github.
   * [vertanux1's channel](https://www.youtube.com/user/vertanux1/) `youtube`
 
 ##### Technique
-* **Resilient Modeling Strategy (RMS)**
-    * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
-      * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
-    * [Learn RMS](http://learnrms.com/)
-
-* **Horizontal Modeling**
-    * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
-    * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
-    * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`
+**Resilient Modeling Strategy (RMS)**
+  * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
+    * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
+  * [Learn RMS](http://learnrms.com/)
+**Horizontal Modeling**
+  * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
+  * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
+  * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`
 
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ I got inspiration from the countless awesome lists in github.
 * [Calculus](https://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/textbook/), by G. Strang. [Direct download](http://ocw.mit.edu/ans7870/resources/Strang/Edited/Calculus/Calculus.pdf) `MIT.edu` 
 * [Online Mathematics Textbooks](http://people.math.gatech.edu/~cain/textbooks/onlinebooks.html), list of free books cured by [G. Cain](http://people.math.gatech.edu/%7Ecain/index.html)
 * [Essentials of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab), by [3Blue1Brown](https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw) `youtube`
-* [Introduction to Tensor Analysis](http://ruina.mae.cornell.edu/Courses/ME6700/references/block_tensor_analysis.pdf), by H.D. Block. Out of print. `Cornell.edu`
+* [Introduction to Tensor Analysis](http://ruina.mae.cornell.edu/Courses/ME6700/references/block_tensor_analysis.pdf), by H.D. Block. *Out of print* `Cornell.edu`
 * [The Matrix Cookbook](http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=3274), by K.B. Petersen, M.S. Pedersen (2012) `DTU.dk`
 
 ### Numerical Analysis
 * [Numerical Analysis for Engineering](https://ece.uwaterloo.ca/~dwharder/NumericalAnalysis/), by D.W. Harder and R. Khoury `UWaterloo.ca`
-* [Numerical Recipes in C](http://www.nrbook.com/a/bookcpdf.html), by W.H. Press, B.P. Flannery, S.A. Teukolsky and W.T. Vetterly (1992) `Cambridge University Press` - `free for personal use`
+* [Numerical Recipes in C](http://www.nrbook.com/a/bookcpdf.html), by W.H. Press, B.P. Flannery, S.A. Teukolsky and W.T. Vetterly (1992) *Free for personal use*
 * [Numerical Methods for PDEs](https://www.youtube.com/channel/UCPVvF1gF2NMNWV-GQCCrpKQ/videos), by Qiqi Wang `MIT.edu` `youtube`
 
 ## Programming
@@ -170,7 +170,7 @@ I got inspiration from the countless awesome lists in github.
 
 ### Python
 * [A Byte of Python](https://python.swaroopch.com/), by [C.H. Swaroop](https://www.swaroopch.com/about/) (2013)
- [Free Copy](https://www.gitbook.com/download/pdf/book/swaroopch/byte-of-python) - [Hard Copy](https://www.swaroopch.com/buybook/)
+ [[Free Copy](https://www.gitbook.com/download/pdf/book/swaroopch/byte-of-python)/[Hard Copy](https://www.swaroopch.com/buybook/)]
 * [Dive into Python 3](http://www.diveintopython3.net/index.html)
 * [Learn X in Y minutes, where X=Python](https://learnxinyminutes.com/docs/python/)
 * [Automate the Boring Stuff with Python](https://automatetheboringstuff.com), a great book for getting a handle on writing python scripts
@@ -204,7 +204,7 @@ I got inspiration from the countless awesome lists in github.
 
 ## Mechanics
 ### <a name="continuum"></a>Continuum Mechanics
-* [Introduction to the Mechanics of a Continuous Medium, L.E. Malvern](https://archive.org/details/in.ernet.dli.2015.140589) (1969) Copyright Expired `Archive.org`
+* [Introduction to the Mechanics of a Continuous Medium, L.E. Malvern](https://archive.org/details/in.ernet.dli.2015.140589) (1969) *Copyright expired* `Archive.org`
 * Many lecture notes links available from [iMechanica](http://imechanica.org/node/1551) (2007)
 * [Applied Mechanics of Solids](http://solidmechanics.org/contents.php), by A.F. Bower (2012) also on [Amazon](https://www.amazon.com/Applied-Mechanics-Solids-Allan-Bower/dp/1439802475/). 
 400 practice problems and sample FEA code.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ I got inspiration from the countless awesome lists in github.
 * [The Engineering of Structures Around Us](https://www.edx.org/course/engineering-structures-around-us-dartmouthx-dart-engs-02-x) `edX Dartmouth`
 * [Elements of Structures](https://www.edx.org/course/elements-structures-mitx-2-01x-1) `edX MIT`
 * [Mechanical Properties of Materials](https://www.mechanicalc.com/reference/material-properties)
+* [Mechanics of Materials](http://madhuvable.org/books-2/introduction/), by [M. Vable](http://pages.mtu.edu/~mavable/) (2009) `MTU.edu` 
 
 
 ## <a name="machine"></a>Theory of Machines

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ I got inspiration from the countless awesome lists in github.
 ---
 
 ## Manufacturing
+### Sheet Metal Forming
+* Mechanics of Sheet Metal Forming, by Z. Marciniak J.L. Duncan and S.J. Hu (2002)
+* [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
 

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ I got inspiration from the countless awesome lists in github.
 ### <a name="continuum"></a>Continuum Mechanics
 * [Introduction to the Mechanics of a Continuous Medium, L.E. Malvern](https://archive.org/details/in.ernet.dli.2015.140589) (1969) *Copyright expired* `Archive.org`
 * Many lecture notes links available from [iMechanica](http://imechanica.org/node/1551) (2007)
-* [Applied Mechanics of Solids](http://solidmechanics.org/contents.php), by A.F. Bower (2012) also on [Amazon](https://www.amazon.com/Applied-Mechanics-Solids-Allan-Bower/dp/1439802475/). 
-400 practice problems and sample FEA code.
+* [Applied Mechanics of Solids](http://solidmechanics.org/contents.php), by [A.F. Bower](https://vivo.brown.edu/display/albower) (2012) [[Amazon](https://www.amazon.com/Applied-Mechanics-Solids-Allan-Bower/dp/1439802475/)]
+&emsp;&bull; <sub><sup>ISBN: 978-1439802472</sup></sub>
 * [Continuum Mechanics](http://www.continuummechanics.org/index.html), by B. McGinty (2012)
 * [Introduction to Continuum Mechanics for Engineers](http://oaktrust.library.tamu.edu/bitstream/handle/1969.1/2501/IntroductionToContinuumMechanicsRevisedEdition.pdf?sequence=6&isAllowed=y), by R.M. Bowen (1989) `Tamu.edu`
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ I got inspiration from the countless awesome lists in github.
 
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
-* Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen <sub><sup>ISBN: 978-0470694527</sup></sub> `Amazon`
+* [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen <sub><sup>ISBN: 978-0470694527</sup></sub> `Amazon`
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design

--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [Altair HyperWorks Online Training series - Meshing, Analysis & Post-processing](https://www.youtube.com/playlist?list=PLJRDa46CU8JIraHKqVbX5K2-nImf1UMHQ)
 
 #### Simscale
+>Website: [https://www.simscale.com/](https://www.simscale.com/)
+
+Cloud based FEA/CFD
+
 
 ### <a name="for-control"></a>For Control Engineering
 ###### MATLAB

--- a/README.md
+++ b/README.md
@@ -316,14 +316,15 @@ I got inspiration from the countless awesome lists in github.
   * [vertanux1's channel](https://www.youtube.com/user/vertanux1/) `youtube`
 
 ##### Technique
-**Resilient Modeling Strategy (RMS)**
-  * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
-    * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
-  * [Learn RMS](http://learnrms.com/)
-**Horizontal Modeling**
-  * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
-  * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
-  * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`
+* **Resilient Modeling Strategy (RMS)**
+    * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
+      * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
+    * [Learn RMS](http://learnrms.com/)
+
+* **Horizontal Modeling**
+    * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
+    * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
+    * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`
 
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ I got inspiration from the countless awesome lists in github.
 * [Elements of Structures](https://www.edx.org/course/elements-structures-mitx-2-01x-1) `edX MIT`
 * [Mechanical Properties of Materials](https://www.mechanicalc.com/reference/material-properties)
 * [Mechanics of Materials](http://madhuvable.org/books-2/introduction/), by [M. Vable](http://pages.mtu.edu/~mavable/) (2009) `MTU.edu` 
-
+### Plasticity
+* [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
   * [Gas Dynamics](#gas-dynamics)
 
 [Manufacturing](#manufacturing)
-  * [CAD/CAM Theory](#cad-theory)
+  * [CAD/CAM](#cadcam)
   * [Sheet Metal Forming](#sheet-metal-forming)
 
 [Finite Element Analysis](#fea)
@@ -303,10 +303,27 @@ I got inspiration from the countless awesome lists in github.
 </div>
 
 ## Manufacturing
-### CAD/CAM Theory
+
+### CAD/CAM
+
+#### Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
 * [Geometric and Solid Modeling](https://www.cs.purdue.edu/homes/cmh/distribution/books/geo.html), by C.M. Hoffman (1992) *Out of Print* `Purdue.edu`
 * [Computer Aided Geometric Design](http://tom.cs.byu.edu/~557/text/cagd.pdf), by T.W. Sederberg (2006) `BYU.edu`
+
+#### Learning and Tutorials
+* [Vertanux1](http://www.vertanux1.com/), Training Guides: Creo, Solidworks, NX, Inventor, Rhino3d.
+  * [vertanux1's channel](https://www.youtube.com/user/vertanux1/) `youtube`
+
+##### Technique
+**Resilient Modeling Strategy (RMS)**
+  * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
+    * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
+  * [Learn RMS](http://learnrms.com/)
+**Horizontal Modeling**
+  * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
+  * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
+  * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`
 
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ I got inspiration from the countless awesome lists in github.
 
 ## Manufacturing
 ### Sheet Metal Forming
-* Mechanics of Sheet Metal Forming, by Z. Marciniak J.L. Duncan and S.J. Hu (2002)
+* [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak J.L. Duncan and S.J. Hu (2002) <sub><sup>ISBN: 978-0750653008</sup></sub> `Amazon`
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -402,8 +402,9 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 *Formely known as* Unigraphics.
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
-OpenSource
-----------
+<br>
+###### OpenSource
+<br>
 
 #### FreeCAD
 >Website: [http://www.openscad.org/](http://www.openscad.org/)

--- a/README.md
+++ b/README.md
@@ -392,43 +392,46 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 ---
 
 ### <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
-* [r/Engineering Fields](https://www.reddit.com/r/engineering/): About all things related to engineering
-* [r/Aerospace](https://www.reddit.com/r/aerospace/): Aerospace Engineering
 * [r/AskEngineers](https://www.reddit.com/r/AskEngineers/): Non-school Q&A
-* [r/AskElectronics](https://www.reddit.com/r/AskElectronics/): CE/EE Q&A
-* [r/BioEngineering](https://www.reddit.com/r/BioEngineering/): Biological
-* [r/Biotech](https://www.reddit.com/r/biotech/): Biotechnology
-* [r/ChemE](https://www.reddit.com/r/chemicalengineering/): Chemical Engineering
-* [r/Civil Engineering](https://www.reddit.com/r/civilengineering/): Civil Engineering
-* [r/Construction](https://www.reddit.com/r/construction/): Construction
-* [r/ECE](https://www.reddit.com/r/ECE/): General EE & CE discussion
-* [r/EE](https://www.reddit.com/r/electricalengineering/): Electrical Engineering
+* [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
+* [r/CFD](https://www.reddit.com/r/CFD/): Computational Fluid Dynamics
+* [r/Engineering Fields](https://www.reddit.com/r/engineering/): About all things related to engineering
 * [r/EngineeringStudents](https://www.reddit.com/r/EngineeringStudents/): For wee engineerlings
+* [r/FEA](https://www.reddit.com/r/fea/): Finite Element Analysis
+* [r/FluidMechanics](https://www.reddit.com/r/FluidMechanics/)
+* [r/Civil Engineering](https://www.reddit.com/r/civilengineering/): Civil Engineering
 * [r/Manufacturing](https://www.reddit.com/r/Manufacturing/): Manufacturing Industry
 * [r/Materials](https://www.reddit.com/r/materials/): Materials Engineering
 * [r/MechE](https://www.reddit.com/r/mechanicalengineering/): Mechanical Engineering
-* [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
-* [r/CFD](https://www.reddit.com/r/CFD/): Computational Fluid Dynamics
-* [r/FEA](https://www.reddit.com/r/fea/): Finite Element Analysis
+###### Misc
+* [r/EngineeringPorn](https://www.reddit.com/r/EngineeringPorn/): porn for engineers (*safe for work*)
+* [r/Lectures](https://www.reddit.com/r/lectures/)
+* [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things
+<details><summary>Other</summary><br/>
+* [r/Aerospace](https://www.reddit.com/r/aerospace/): Aerospace Engineering
+* [r/AskElectronics](https://www.reddit.com/r/AskElectronics/): CE/EE Q&A
 * [r/AskScience](https://www.reddit.com/r/AskScience/): No-nonsense science Q&A
+* [r/BioEngineering](https://www.reddit.com/r/BioEngineering/): Biological
 * [r/Biology](https://www.reddit.com/r/biology/)
+* [r/Biotech](https://www.reddit.com/r/biotech/): Biotechnology
+* [r/ChemE](https://www.reddit.com/r/chemicalengineering/): Chemical Engineering
 * [r/Chemistry](https://www.reddit.com/r/chemistry/)
 * [r/Coding](https://www.reddit.com/r/coding/)
 * [r/ComputerScience](https://www.reddit.com/r/ComputerScience/)
+* [r/Construction](https://www.reddit.com/r/construction/): Construction
+* [r/CSBooks](https://www.reddit.com/r/csbooks/): Computer Science
+* [r/ECE](https://www.reddit.com/r/ECE/): General EE & CE discussion
+* [r/ECEComponentExchange](https://www.reddit.com/r/ECEComponentExchange/): Parts swap
+* [r/EE](https://www.reddit.com/r/electricalengineering/): Electrical Engineering
+* [r/EEBooks](https://www.reddit.com/r/eebooks/): Electrical Engineering
 * [r/Electronics](https://www.reddit.com/r/electronics/)
-* [r/Lectures](https://www.reddit.com/r/lectures/)
 * [r/Math](https://www.reddit.com/r/math/)
+* [r/MathBooks](https://www.reddit.com/r/mathbooks/): Mathematics
 * [r/Physics](https://www.reddit.com/r/physics/)
+* [r/PhysicsBooks](https://www.reddit.com/r/physicsbooks/): Physics
 * [r/Programming](https://www.reddit.com/r/programming/)
 * [r/Science](https://www.reddit.com/r/science/)
-* [r/FluidMechanics](https://www.reddit.com/r/FluidMechanics/)
-* [r/CSBooks](https://www.reddit.com/r/csbooks/): Computer Science
-* [r/EEBooks](https://www.reddit.com/r/eebooks/): Electrical Engineering
-* [r/MathBooks](https://www.reddit.com/r/mathbooks/): Mathematics
-* [r/PhysicsBooks](https://www.reddit.com/r/physicsbooks/): Physics
-* [r/ECEComponentExchange](https://www.reddit.com/r/ECEComponentExchange/): Parts swap
-* [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things
-* [r/EngineeringPorn](https://www.reddit.com/r/EngineeringPorn/): porn for engineers (*safe for work*)
+</details>
 
 
 ## <a name="publication"></a>Top Publication Venues for Different Fields

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <sub><sup>ISBN: 978-0471274711/sup></sub> `Amazon`
-* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <sub><sup>ISBN: 978-0073398174/sup></sub> `Amazon`
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <sub><sup>ISBN: 978-0471274711</sup></sub> `Amazon`
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <sub><sup>ISBN: 978-0073398174</sup></sub> `Amazon`
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
@@ -264,11 +264,11 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <sub><sup>ISBN: 978-0471442509/sup></sub> `Amazon`
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <sub><sup>ISBN: 978-0471442509</sup></sub> `Amazon`
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  <sub><sup>ISBN: 978-0072424430/sup></sub> `Amazon`
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  <sub><sup>ISBN: 978-0072424430</sup></sub> `Amazon`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -316,11 +316,11 @@ I got inspiration from the countless awesome lists in github.
   * [vertanux1's channel](https://www.youtube.com/user/vertanux1/) `youtube`
 
 ##### Technique
-**Resilient Modeling Strategy (RMS)**
-  * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gbebhard (Slides) `Siemens`
+* **Resilient Modeling Strategy (RMS)**
+  * [A Resilient Modeling Strategy](https://community.plm.automation.siemens.com/siemensplm/attachments/siemensplm/solid-edge-tkb/159/1/122%20-%20A%20Resilient%20Modeling%20Strategy%20%20-%20Richard%20Gebhard.pdf), by R. Gebhard (Slides) `Siemens`
     * [RMS Presentation](https://www.youtube.com/watch?v=QGj3hwtyZxQ) `youtube`
   * [Learn RMS](http://learnrms.com/)
-**Horizontal Modeling**
+* **Horizontal Modeling**
   * [Horizontally structured CAD/CAM modeling-vertical to horizontal conversion [US 7472044 B2]](https://www.google.com/patents/US7472044) `patent`
   * [Product/Process Design using Horizontally Structured Modeling](www.dezignstuff.com/swparts/Delphi-Burke.pdf), by Delphi Automotive `dezignstuff.com`
   * [Going Horizontal (The failed promise of parametric CAD, part 4)](http://www.3dcadworld.com/going-horizontal/) `3dcadworld.com`

--- a/README.md
+++ b/README.md
@@ -403,7 +403,9 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [r/Manufacturing](https://www.reddit.com/r/Manufacturing/): Manufacturing Industry
 * [r/Materials](https://www.reddit.com/r/materials/): Materials Engineering
 * [r/MechanicalEngineering](https://www.reddit.com/r/mechanicalengineering/): Mechanical Engineering
+
 Misc
+
 * [r/EngineeringPorn](https://www.reddit.com/r/EngineeringPorn/): porn for engineers (*safe for work*)
 * [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things
 <details><summary>Other</summary><br/>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 <a name="toc"></a>Table of Contents
 -----------------
-<details open><summary><sup>Hide/Show</sup></summary><br/>
+<details open><summary><sup>Hide</sup>/<sub>Show</sub></summary><br/>
 
 [Preamble](#preamble)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
   * [Continuum Mechanics](#continuum)
   * [Statics and Dynamics](#statics&dynamics)
   * [Strength of Materials](#strength)
+  * [Plasticity](#plasticity)
 
 [Theory of Machines](#machine)
   * [Mechanism Design](#mechanism-design)
@@ -78,8 +79,8 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 [Sub Reddits](#subreddits)
 
 [Top Publication Venues for Different Fields](#publication)
-  * Journals
-  * Magazines
+  * [Journals](#journals)
+  * [Magazines](#magazines)
 
 [Competitions](#competition)
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,10 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 *Formely known as* Unigraphics.
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
+#### Creo
+*Formerly known as* Pro/ENGINEER.
+>Website: [https://www.ptc.com/](https://www.ptc.com/)
+>Student Edition: [https://www.ptc.com/en/academic-program/products/free-software](https://www.ptc.com/en/academic-program/products/free-software) 
 
 
 
@@ -453,10 +457,6 @@ Script based modeller
 
 #### Solid Edge
 
-#### Creo 
-*Formerly known as* Pro/ENGINEER.
->Website: [https://www.ptc.com/](https://www.ptc.com/)
->Student Edition: [https://www.ptc.com/en/academic-program/products/free-software](https://www.ptc.com/en/academic-program/products/free-software) 
 
 
 #### SpaceClaim

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="math"></a>Mathematics
@@ -199,7 +199,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## Mechanics
@@ -290,7 +290,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## Manufacturing
@@ -304,7 +304,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="fea"></a>Finite Element Analysis
@@ -324,7 +324,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="software"></a>Software Packages
@@ -422,7 +422,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
@@ -473,7 +473,7 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="publication"></a>Top Publication Venues for Different Fields
@@ -494,7 +494,7 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="competition"></a>Competitions
@@ -523,7 +523,7 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
 
 ## <a name="certification"></a>Qualifying/Certification Examinations

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
   * [Gas Dynamics](#gas-dynamics)
 
 [Manufacturing](#manufacturing)
+  * [Sheet Metal Forming](#sheet-metal-forming)
+  * [CAD/CAM Theory](#cad-theory)
 
 [Finite Element Analysis](#fea)
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 
 *Geometric Kernel* [OpenCASCADE](https://github.com/tpaviot/oce)
 
+* [A FreeCAD mnaual](https://www.gitbook.com/book/yorikvanhavre/a-freecad-manual/details) `GitBook`
 * [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), "python based language for building parametric models" [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
   * [CadQuery Documentation](http://dcowden.github.io/cadquery/)
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 ### Journals
 
 #### Open Access
+* [DOAJ, Directory of Open Acess Journals](https://doaj.org/)
 * [SCIRP, Modern Mechanical Engineering](http://www.scirp.org/journal/mme/)
 * [SAGE journals, Advances in MEchanical Engineering](http://journals.sagepub.com/loi/adea)
 

--- a/README.md
+++ b/README.md
@@ -403,9 +403,8 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [r/Manufacturing](https://www.reddit.com/r/Manufacturing/): Manufacturing Industry
 * [r/Materials](https://www.reddit.com/r/materials/): Materials Engineering
 * [r/MechE](https://www.reddit.com/r/mechanicalengineering/): Mechanical Engineering
-###### Misc
+Misc
 * [r/EngineeringPorn](https://www.reddit.com/r/EngineeringPorn/): porn for engineers (*safe for work*)
-* [r/Lectures](https://www.reddit.com/r/lectures/)
 * [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things
 <details><summary>Other</summary><br/>
 
@@ -426,6 +425,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
   * [r/EE](https://www.reddit.com/r/electricalengineering/): Electrical Engineering
   * [r/EEBooks](https://www.reddit.com/r/eebooks/): Electrical Engineering
   * [r/Electronics](https://www.reddit.com/r/electronics/)
+  * [r/Lectures](https://www.reddit.com/r/lectures/)
   * [r/Math](https://www.reddit.com/r/math/)
   * [r/MathBooks](https://www.reddit.com/r/mathbooks/): Mathematics
   * [r/Physics](https://www.reddit.com/r/physics/)
@@ -434,15 +434,16 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
   * [r/Science](https://www.reddit.com/r/science/)
 </details>
 
+---
 
 ## <a name="publication"></a>Top Publication Venues for Different Fields
 
 ### Journals
 
 #### Open Access
-* [DOAJ, Directory of Open Acess Journals](https://doaj.org/)
-* [SCIRP, Modern Mechanical Engineering](http://www.scirp.org/journal/mme/)
-* [SAGE journals, Advances in MEchanical Engineering](http://journals.sagepub.com/loi/adea)
+* [DOAJ](https://doaj.org/), Directory of Open Acess Journals
+* [SCIRP](http://www.scirp.org/journal/mme/), Modern Mechanical Engineering
+* [SAGE journals](http://journals.sagepub.com/loi/adea), Advances in Mechanical Engineering
 
 ### Magazines
 * [Machine Design](http://machinedesign.com/)

--- a/README.md
+++ b/README.md
@@ -402,21 +402,26 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 *Formely known as* Unigraphics.
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
-##### OpenSource
+OpenSource
+----------
+
 #### FreeCAD
-Website: [http://www.openscad.org/](http://www.openscad.org/)
+>Website: [http://www.openscad.org/](http://www.openscad.org/)
+
 *Geometric Kernel* [OpenCASCADE](https://github.com/tpaviot/oce)
 
 * [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), "python based language for building parametric models" [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
   * [CadQuery Documentation](http://dcowden.github.io/cadquery/)
 
 #### OpenSCAD
-Website: [http://www.openscad.org/](http://www.openscad.org/)
+>Website: [http://www.openscad.org/](http://www.openscad.org/)
+
 Script based modeller
+
 *Geometric Kernel* [OpenCSG](http://opencsg.org/) + [CGAL](https://www.cgal.org/)
 
 #### BRL-CAD
-Website: [http://brlcad.org/](http://brlcad.org/)
+>Website: [http://brlcad.org/](http://brlcad.org/)
 
 <details><summary>Coming Soon</summary><br/>
 <!-- Empty sections Bloat: move out when ready  -->

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 Table of Contents
 -----------------
-<details open><summary>Hide</summary>
-
+<details open><summary>Hide/Show</summary><br/>
 
 [Preamble](#preamble)
 

--- a/README.md
+++ b/README.md
@@ -251,23 +251,24 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* Moran, Michael J., Shapiro, Howard N.  *Fundamentals of Engineering Thermodynamics*.  5th Edition.  John Wiley & Sons.  Hoboken, NJ.  2004.  ISBN: 978-0471274711.
-* Thermodynamics: An Engineering Approach by Yunus A. Cengel, Michael A. Boles
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. ISBN: 978-0471274711 `Amazon`
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. ISBN: 978-0073398174 `Amazon`
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* Incropera, Frank P., DeWitt, David P.  *Fundamentals of Heat and Mass Transfer*.  5th Edition.  John Wiley & Sons.  Hoboken, NJ.  2002.  ISBN: 978-0471386506.
+* Incropera, Frank P., DeWitt, David P.  *
+[Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. [ISBN: 978-0471386506] `Amazon`
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* Munson, Bruce R., Young, Donald F., Okiishi, Theodore H.  *Fundamentals of Fluid Mechanics*.  4th Edition.  John Wiley & Sons.  Hoboken, NJ.  2001.  ISBN: 978-0471442509.
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. ISBN: 978-0471442509 `Amazon`
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* Anderson, John D.  *Modern Compressible Flow: With Historical Perspective*.  3rd Edition.  McGraw-Hill.  New York, NY.  2003.  ISBN: 978-0072424430.
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  ISBN: 978-0072424430 `Amazon`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ I got inspiration from the countless awesome lists in github.
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 * [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
-<sup>ISBN: 978-0470694527</sup>
+<br/><sup><sup>ISBN: 978-0470694527</sup></sup>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -257,15 +257,15 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
 * [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
-<sup>ISBN: 978-0471274711</sup>
+<br/><sup><sup>ISBN: 978-0471274711</sup></sup>
 * [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
-<sup>ISBN: 978-0073398174</sup>
+<br/><sup><sup>ISBN: 978-0073398174</sup></sup>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
 * [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
-<sup>ISBN: 978-0471386506</sup>
+<br/><sup><sup>ISBN: 978-0471386506</sup></sup>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
@@ -273,19 +273,19 @@ I got inspiration from the countless awesome lists in github.
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
 * [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
-<sup>ISBN: 978-0471442509</sup>
+<br/><sup><sup>ISBN: 978-0471442509</sup></sup>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
 * [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
-<sup>ISBN: 978-0072424430</sup>
+<br/><sup><sup>ISBN: 978-0072424430</sup></sup>
 
 ---
 
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
-<sup>ISBN: 978-0750653008</sup>
+<br/><sup><sup>ISBN: 978-0750653008</sup></sup>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ I got inspiration from the countless awesome lists in github.
 
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
-* [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen <sub><sup>ISBN: 978-0470694527</sup></sub> `Amazon`
+* [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
+<sup>ISBN: 978-0470694527</sup>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -255,30 +256,36 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <sub><sup>ISBN: 978-0471274711</sup></sub> `Amazon`
-* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <sub><sup>ISBN: 978-0073398174</sup></sub> `Amazon`
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
+<sup>ISBN: 978-0471274711</sup>
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
+<sup>ISBN: 978-0073398174</sup>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <sub><sup>ISBN: 978-0471386506</sup></sub> `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
+<sup>ISBN: 978-0471386506</sup>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <sub><sup>ISBN: 978-0471442509</sup></sub> `Amazon`
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
+<sup>ISBN: 978-0471442509</sup>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  <sub><sup>ISBN: 978-0072424430</sup></sub> `Amazon`
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
+<sup>ISBN: 978-0072424430</sup>
 
 ---
 
 ## Manufacturing
 ### Sheet Metal Forming
-* [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) <sub><sup>ISBN: 978-0750653008</sup></sub> `Amazon`
+* [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
+<sup>ISBN: 978-0750653008</sup>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="right">
 
-|&bigstar; **CTRL+D**|
+|&bigstar; **Ctrl+D**|
 |---|
 </div>
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Cloud based FEA/CFD
 #### Creo
 *Formerly known as* Pro/ENGINEER.
 >Website: [https://www.ptc.com/](https://www.ptc.com/)
+>
 >Student Edition: [https://www.ptc.com/en/academic-program/products/free-software](https://www.ptc.com/en/academic-program/products/free-software) 
 
 #### SolidWorks

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="math"></a>Mathematics
 ### Calculus and Linear Algebra
 * [Calculus](https://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/textbook/), by G. Strang. [Direct download](http://ocw.mit.edu/ans7870/resources/Strang/Edited/Calculus/Calculus.pdf) `MIT.edu` 
@@ -199,7 +199,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## Mechanics
 ### <a name="continuum"></a>Continuum Mechanics
 * [Introduction to the Mechanics of a Continuous Medium, L.E. Malvern](https://archive.org/details/in.ernet.dli.2015.140589) (1969) Copyright Expired `Archive.org`
@@ -289,7 +289,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
@@ -302,7 +302,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div
+</div> 
 ## <a name="fea"></a>Finite Element Analysis
 * [Finite Element Procedures](http://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf), by [K.J. Bathe](http://meche.mit.edu/people/faculty/kjb@mit.edu) (2014) `MIT.edu`
 * [Introduction to the Finite Element Method](http://hyfem.com/HyFem/fem.pdf), by C.S. Jog
@@ -321,7 +321,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="software"></a>Software Packages
 ### <a name="for-fea"></a>For Finite Element Analysis
 * [Code_Aster](https://www.code-aster.org/)
@@ -418,7 +418,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
 * [r/AskEngineers](https://www.reddit.com/r/AskEngineers/): Non-school Q&A
 * [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
@@ -468,7 +468,7 @@ Misc
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="publication"></a>Top Publication Venues for Different Fields
 
 ### Journals
@@ -488,7 +488,7 @@ Misc
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="competition"></a>Competitions
 ### SAE Competitions
 
@@ -516,7 +516,7 @@ Misc
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div>
+</div> 
 ## <a name="certification"></a>Qualifying/Certification Examinations
 Qualifying examinations are a kind of certification to engineers - PE in USA, GATE in India
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ Script based modeller
 
 #### Creo 
 *Formerly known as* Pro/ENGINEER.
+>Website: [https://www.ptc.com/](https://www.ptc.com/)
+>Student Edition: [https://www.ptc.com/en/academic-program/products/free-software](https://www.ptc.com/en/academic-program/products/free-software) 
 
 
 #### SpaceClaim

--- a/README.md
+++ b/README.md
@@ -425,20 +425,28 @@ Script based modeller
 
 <details><summary>Coming Soon</summary><br/>
 <!-- Empty sections Bloat: move out when ready  -->
+
 #### SolidWorks
+
 #### Solid Edge
+
 #### Creo 
 *Formerly known as* Pro/ENGINEER.
+
 #### OnShape
 Cloud Based CAD
 Website: [https://www.onshape.com/](https://www.onshape.com/)
 
 #### SpaceClaim
+
 #### AutoCAD
 </details>
 <details><summary>Surface Modelling</summary><br/>
+
 #### Blender
+
 #### SketchUp
+
 #### <a name="#rhino"></a>Rhinoceros 3D
 </details>
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
 
+
+
 ###### OpenSource
 
 
@@ -419,6 +421,11 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 
 * [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), "python based language for building parametric models" [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
   * [CadQuery Documentation](http://dcowden.github.io/cadquery/)
+
+#### OnShape
+>Website: [https://www.onshape.com/](https://www.onshape.com/)
+
+Cloud Based CAD
 
 #### OpenSCAD
 >Website: [http://www.openscad.org/](http://www.openscad.org/)
@@ -440,9 +447,6 @@ Script based modeller
 #### Creo 
 *Formerly known as* Pro/ENGINEER.
 
-#### OnShape
->Website: [https://www.onshape.com/](https://www.onshape.com/)
-Cloud Based CAD
 
 #### SpaceClaim
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ I got inspiration from the countless awesome lists in github.
 * [Animated Engines](http://www.animatedengines.com/), animated engines
 * [thang010146](https://www.youtube.com/user/thang010146/videos), 2100+ animated mechanisms (downloadable) `youtube`
 * [DMG Lib, Digital Mechanism and Gear Library](http://www.dmg-lib.org/dmglib/main/portal.jsp)
+* [KMODDL](http://kmoddl.library.cornell.edu/), collection of mechanism and machines `Cornell.edu`
 
 #### Patents
 * [Google Patents](https://www.google.com/patents/)

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ I got inspiration from the countless awesome lists in github.
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. ISBN: 978-0471386506 `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <sub>ISBN: 978-0471386506</sub> `Amazon`
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Table of Contents
 ---
 
 
-
-### Preamble
+## Preamble
 I got inspiration from the countless awesome lists in github.
 
 ## <a name="opencourse"></a>Open Courses
@@ -145,6 +144,10 @@ I got inspiration from the countless awesome lists in github.
 * [Hackaday](https://hackaday.com/)
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## <a name="math"></a>Mathematics
 ### Calculus and Linear Algebra
@@ -194,6 +197,10 @@ I got inspiration from the countless awesome lists in github.
 * [Introduction to Programming with Fortran 95](https://www.fortrantutorial.com/documents/IntroductionToFTN95.pdf)
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## Mechanics
 ### <a name="continuum"></a>Continuum Mechanics
@@ -281,6 +288,10 @@ I got inspiration from the countless awesome lists in github.
 &emsp;&bull; <sup><sup>ISBN: 978-0072424430</sup></sup>
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## Manufacturing
 ### Sheet Metal Forming
@@ -291,6 +302,10 @@ I got inspiration from the countless awesome lists in github.
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## <a name="fea"></a>Finite Element Analysis
 * [Finite Element Procedures](http://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf), by [K.J. Bathe](http://meche.mit.edu/people/faculty/kjb@mit.edu) (2014) `MIT.edu`
@@ -307,6 +322,10 @@ I got inspiration from the countless awesome lists in github.
 * [List of FE packages](https://en.wikipedia.org/wiki/List_of_finite_element_software_packages) `wikipedia`
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## <a name="software"></a>Software Packages
 ### <a name="for-fea"></a>For Finite Element Analysis
@@ -401,8 +420,12 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 #### <a name="#brlcad"></a>BRL-CAD
 
 ---
+<div align="right">
 
-### <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
+
+## <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
 * [r/AskEngineers](https://www.reddit.com/r/AskEngineers/): Non-school Q&A
 * [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
 * [r/CFD](https://www.reddit.com/r/CFD/): Computational Fluid Dynamics
@@ -448,6 +471,10 @@ Misc
 </details>
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## <a name="publication"></a>Top Publication Venues for Different Fields
 
@@ -465,6 +492,10 @@ Misc
 * [Popular Science](http://www.popsci.com/)
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
 
 ## <a name="competition"></a>Competitions
 ### SAE Competitions
@@ -490,6 +521,11 @@ Misc
 * [Elsevier 3D Printing Grand Challenge](http://www.materialstoday.com/elsevier-3d-printing-grand-challenge)
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#top)</sup> &Hat;
+</div>
+
 ## <a name="certification"></a>Qualifying/Certification Examinations
 Qualifying examinations are a kind of certification to engineers - PE in USA, GATE in India
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Cloud based FEA/CFD
 *Geometric Kernel* [OpenCASCADE](https://github.com/tpaviot/oce)
 
 * [A FreeCAD mnaual](https://www.gitbook.com/book/yorikvanhavre/a-freecad-manual/details) `GitBook`
-* [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), "python based language for building parametric models" [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
+* [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), python based language for building parametric models [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
   * [CadQuery Documentation](http://dcowden.github.io/cadquery/)
 
 #### OnShape

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 ---
 
 <details open>
-<summary>Table of Contents</summary>
------------------
+<summary><h1>Table of Contents</h1></summary>
+
+***
 
 [Preamble](#preamble)
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,9 @@ I got inspiration from the countless awesome lists in github.
 * [Code_Aster](https://www.code-aster.org/)
 * [CalculiX](http://www.calculix.de/)
 * [Elmer](https://www.csc.fi/web/elmer)
-* [awesome-cae](https://github.com/qd-cae/awesome-CAE)
+
+###### Further reading
+* [awesome-CAE](https://github.com/qd-cae/awesome-CAE) `github`
 
 #### ANSYS
 [Student/Free version](http://www.ansys.com/academic/free-student-products): Available for anyone with limited capability and usage for learning purpose. This is a video explaining how to [download and install ANSYS Student Release 17.2 from Ansys How To official channel](https://www.youtube.com/watch?v=rV-xr_D18hM)

--- a/README.md
+++ b/README.md
@@ -251,24 +251,24 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <small>ISBN: 978-0471274711</small> `Amazon`
-* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <small>ISBN: 978-0073398174</small> `Amazon`
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. ISBN: 978-0471274711 `Amazon`
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. ISBN: 978-0073398174 `Amazon`
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <small>ISBN: 978-0471386506</small> `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. ISBN: 978-0471386506 `Amazon`
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <small>ISBN: 978-0471442509</small> `Amazon`
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. ISBN: 978-0471442509 `Amazon`
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. <small>ISBN: 978-0072424430</small> `Amazon`
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  ISBN: 978-0072424430 `Amazon`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 ---
 
-Table of Contents
+<a name="toc"></a>Table of Contents
 -----------------
 <details open><summary>Hide/Show</summary><br/>
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 
 #### Open Access
 * [SCIRP, Modern Mechanical Engineering](http://www.scirp.org/journal/mme/)
+* [SAGE journals, Advances in MEchanical Engineering](http://journals.sagepub.com/loi/adea)
 
 ### Magazines
 * [Machine Design](http://machinedesign.com/)

--- a/README.md
+++ b/README.md
@@ -423,9 +423,8 @@ Script based modeller
 #### BRL-CAD
 >Website: [http://brlcad.org/](http://brlcad.org/)
 
-<details><summary>Coming Soon</summary><br/>
+<details><summary>Coming Soon</summary>
 <!-- Empty sections Bloat: move out when ready  -->
-
 #### SolidWorks
 
 #### Solid Edge
@@ -441,8 +440,7 @@ Website: [https://www.onshape.com/](https://www.onshape.com/)
 
 #### AutoCAD
 </details>
-<details><summary>Surface Modelling</summary><br/>
-
+<details><summary>Surface Modelling</summary>
 #### Blender
 
 #### SketchUp

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ I got inspiration from the countless awesome lists in github.
 * [GlobalSpec](http://insights.globalspec.com/)
 * [Hackaday](https://hackaday.com/)
 * [Plastics Engineering Blog](https://plasticsengineeringblog.com/)
+* [3D CAD World](http://www.3dcadworld.com/)
 
 ---
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ I got inspiration from the countless awesome lists in github.
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 * [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0470694527</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0470694527</sup></sub>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -264,15 +264,15 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
 * [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0471274711</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0471274711</sup></sub>
 * [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0073398174</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0073398174</sup></sub>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
 * [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0471386506</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0471386506</sup></sub>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
@@ -280,12 +280,12 @@ I got inspiration from the countless awesome lists in github.
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
 * [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0471442509</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0471442509</sup></sub>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
 * [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0072424430</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0072424430</sup></sub>
 
 ---
 <div align="right">
@@ -296,7 +296,7 @@ I got inspiration from the countless awesome lists in github.
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
-&emsp;&bull; <sup><sup>ISBN: 978-0750653008</sup></sup>
+&emsp;&bull; <sub><sup>ISBN: 978-0750653008</sup></sub>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -251,24 +251,24 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. ISBN: 978-0471274711 `Amazon`
-* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. ISBN: 978-0073398174 `Amazon`
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <small>ISBN: 978-0471274711</small> `Amazon`
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <small>ISBN: 978-0073398174</small> `Amazon`
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. ISBN: 978-0471386506 `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <small>ISBN: 978-0471386506</small> `Amazon`
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. ISBN: 978-0471442509 `Amazon`
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <small>ISBN: 978-0471442509</small> `Amazon`
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  ISBN: 978-0072424430 `Amazon`
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. <small>ISBN: 978-0072424430</small> `Amazon`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
   * [Gas Dynamics](#gas-dynamics)
 
 [Manufacturing](#manufacturing)
-  * [Sheet Metal Forming](#sheet-metal-forming)
   * [CAD/CAM Theory](#cad-theory)
+  * [Sheet Metal Forming](#sheet-metal-forming)
 
 [Finite Element Analysis](#fea)
 
@@ -302,12 +302,13 @@ I got inspiration from the countless awesome lists in github.
 </div>
 
 ## Manufacturing
+### CAD/CAM Theory
+* [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
+
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
 &emsp;&bull; <sub><sup>ISBN: 978-0750653008</sup></sub>
 * [SheetMetal.me](http://sheetmetal.me/)
-### CAD/CAM Theory
-* [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
 
 ---
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ I got inspiration from the countless awesome lists in github.
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
 * [Geometric and Solid Modeling](https://www.cs.purdue.edu/homes/cmh/distribution/books/geo.html), by C.M. Hoffman (1992) *Out of Print* `Purdue.edu`
+* [Computer Aided Geometric Design](http://tom.cs.byu.edu/~557/text/cagd.pdf), by T.W. Sederberg (2006) `BYU.edu`
 
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -439,8 +439,14 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 >Website: [https://www.ptc.com/](https://www.ptc.com/)
 >Student Edition: [https://www.ptc.com/en/academic-program/products/free-software](https://www.ptc.com/en/academic-program/products/free-software) 
 
+#### SolidWorks
 
+* [Solidworks Resources](http://www.solidworks.com/sw/resources/solidworks-tutorials.htm) `Solidworks`
 
+#### Solid Edge
+
+* [Solid Edge Resources](https://community.plm.automation.siemens.com/t5/Solid-Edge/ct-p/solid-edge) `Siemens`
+ 
 ###### OpenSource
 
 
@@ -471,11 +477,6 @@ Script based modeller
 <details><summary><b>Coming Soon</b></summary>
 <!-- Empty sections Bloat: move out when ready  -->
 
-#### SolidWorks
-
-#### Solid Edge
-
-
 
 #### SpaceClaim
 
@@ -487,7 +488,7 @@ Script based modeller
 
 #### SketchUp
 
-#### <a name="#rhino"></a>Rhinoceros 3D
+#### Rhinoceros 3D
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ I got inspiration from the countless awesome lists in github.
 ## <a name="math"></a>Mathematics
 ### Calculus and Linear Algebra
 * [Calculus](https://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/textbook/), by G. Strang. [Direct download](http://ocw.mit.edu/ans7870/resources/Strang/Edited/Calculus/Calculus.pdf) `MIT.edu` 
-* [Online Mathematics Textbooks](http://people.math.gatech.edu/~cain/textbooks/onlinebooks.html), list of free books cured by G. Cain
+* [Online Mathematics Textbooks](http://people.math.gatech.edu/~cain/textbooks/onlinebooks.html), list of free books cured by [G. Cain](http://people.math.gatech.edu/%7Ecain/index.html)
 * [Essentials of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab), by [3Blue1Brown](https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw) `youtube`
 * [Introduction to Tensor Analysis](http://ruina.mae.cornell.edu/Courses/ME6700/references/block_tensor_analysis.pdf), by H.D. Block. Out of print. `Cornell.edu`
 * [The Matrix Cookbook](http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=3274), by K.B. Petersen, M.S. Pedersen (2012) `DTU.dk`

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ I got inspiration from the countless awesome lists in github.
 * [Meshing of complex geometrical domains](http://engineering.stackexchange.com/a/7326/2918) `stackexchange`
 * [What Is a Good Linear Finite Element?](http://people.eecs.berkeley.edu/~jrs/papers/elemj.pdf) by [J.R. Shewchuk](http://people.eecs.berkeley.edu/~jrs/) (2002) `Berkeley.edu`
 * [How Can I learn Finite Element Analysis?](https://www.simscale.com/blog/2016/11/learn-finite-element-analysis-fea/) `simscale`
+* [Why CAD Surface Geometry is Inexact](https://blog.pointwise.com/2017/11/29/why-cad-surface-geometry-is-inexact/) `pointwise`
 
 #### Code
 * [deal.II](https://www.dealii.org/) (C++ library)

--- a/README.md
+++ b/README.md
@@ -434,8 +434,8 @@ Script based modeller
 *Formerly known as* Pro/ENGINEER.
 
 #### OnShape
+>Website: [https://www.onshape.com/](https://www.onshape.com/)
 Cloud Based CAD
-Website: [https://www.onshape.com/](https://www.onshape.com/)
 
 #### SpaceClaim
 

--- a/README.md
+++ b/README.md
@@ -408,9 +408,9 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 *Formely known as* Unigraphics.
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
-<br>
+
 ###### OpenSource
-<br>
+
 
 #### FreeCAD
 >Website: [http://www.openscad.org/](http://www.openscad.org/)

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ I got inspiration from the countless awesome lists in github.
 <div align="right">
 
 <sup>[Back to Top](#toc)</sup> &Hat;
-</div> 
+</div>  
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ I got inspiration from the countless awesome lists in github.
 * [Animated Engines](http://www.animatedengines.com/), animated engines
 * [thang010146](https://www.youtube.com/user/thang010146/videos), 2100+ animated mechanisms (downloadable) `youtube`
 * [DMG Lib, Digital Mechanism and Gear Library](http://www.dmg-lib.org/dmglib/main/portal.jsp)
-* [KMODDL](http://kmoddl.library.cornell.edu/), collection of mechanism and machines `Cornell.edu`
+* [KMODDL](http://kmoddl.library.cornell.edu/e-books.php), collection of mechanism and machines `Cornell.edu`
 
 #### Patents
 * [Google Patents](https://www.google.com/patents/)

--- a/README.md
+++ b/README.md
@@ -336,33 +336,19 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 [Student/Free version](http://www.altairuniversity.com/hyperworks-licensing/): Available only for students with limited capability.
 
 * [HyperMesh | Pre processing | 2D | 3D | Meshing | ANSYS | Tutorial |](https://www.youtube.com/playlist?list=PLOahOE6DpL4puVylWdpHWRoGhIfswDc6T)
-
 * [HyperMesh & Optistruct Solved Tutorials AOC-2016 Contest](https://www.youtube.com/playlist?list=PL1u26y75SCrBpe7SWbMEgOe0Ty3O7gPGS)
-
 * [Optistruct for Optimization AOC-2016 Contest](https://www.youtube.com/playlist?list=PL1u26y75SCrBHdDPaA2Thry6qwuSu2Uf_)
-
 * [Optistruct by Anil Kumar](https://www.youtube.com/playlist?list=PLrXG4nKgafb8IWo7q4fTXH5SX4TjsV0Pp)
-
 * [Hyperworks Optistruct Tutorials by Manuel Ramsaier](https://www.youtube.com/playlist?list=PLE4jpqcRJiBpJvHgHDmTZxi0J_RiXAz-6)
-
 * [HyperWorks Tips & Tricks by Altair](https://www.youtube.com/playlist?list=PLRqUDK2aqvkDi21dCVdT0uJFTzslg67gz)
-
 * [Hypermesh basics by Apoorv Bapat](https://www.youtube.com/playlist?list=PLAsvHPJrmoWZNrnXYYLkvV2ElNe2g3zxX)
-
 * [Hypermesh Tutorial by TheScientifica](https://www.youtube.com/playlist?list=PL86AF55AB0D9AA70C)
-
 * [Hypermesh Tutorials Collections by Fazle ahad](https://www.youtube.com/playlist?list=PLvVR-5zpzf0HQVpv3gs58U620ekf--IsJ)
-
 * [SAEINDIA BAJA 2016 Online Training Session](https://www.youtube.com/playlist?list=PLJRDa46CU8JKZyLbEOxuACCbHi0_jk03X)
-
 * [Dynamic Analysis of Roll Cage](https://www.youtube.com/playlist?list=PLJRDa46CU8JIch9nYk54DzrcyoRJgkQDl)
-
 * [SUPRA SAE India 2016 Pre-virtual online Training Session](https://www.youtube.com/playlist?list=PLJRDa46CU8JLDsfzy0ZB06KLeIBKVi6Aw)
-
 * [Formula Student India Online Training Series](https://www.youtube.com/playlist?list=PLJRDa46CU8JLaBjaiwbePkUKJeSqQyA-P)
-
 * [BAJA Student India Online Training Series](https://www.youtube.com/playlist?list=PLJRDa46CU8JLLiGpLtlhkMSMDjTVzW_1r)
-
 * [Altair HyperWorks Online Training series - Meshing, Analysis & Post-processing](https://www.youtube.com/playlist?list=PLJRDa46CU8JIraHKqVbX5K2-nImf1UMHQ)
 
 ### <a name="for-control"></a>For Control Engineering

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 [Student Edition](https://academy.3ds.com/en/software/catia-v5-student-edition) until Nov. 26th. *Promo code*: `CATIA4FREE17`
 
 #### <a name="#nx"></a>Siemens NX Unigraphics
+* [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
 #### <a name="#solidworks"></a>SolidWorks
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ I got inspiration from the countless awesome lists in github.
 * [507 Mechanical Movements](http://507movements.com/), animated movements
 * [Animated Engines](http://www.animatedengines.com/), animated engines
 * [thang010146](https://www.youtube.com/user/thang010146/videos), 2100+ animated mechanisms (downloadable) `youtube`
-* [DMG Lib, Digital Mechanism and Gear Library](http://www.dmg-lib.org/dmglib/main/portal.jsp)
+* [DMG Lib](http://www.dmg-lib.org/dmglib/main/portal.jsp), Digital Mechanism and Gear Library
 * [KMODDL](http://kmoddl.library.cornell.edu/e-books.php), collection of mechanism and machines `Cornell.edu`
 
 #### Patents

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ I got inspiration from the countless awesome lists in github.
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 * [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0470694527</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0470694527</sup></sup>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -257,15 +257,15 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
 * [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0471274711</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0471274711</sup></sup>
 * [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0073398174</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0073398174</sup></sup>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
 * [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0471386506</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0471386506</sup></sup>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
@@ -273,19 +273,19 @@ I got inspiration from the countless awesome lists in github.
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
 * [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0471442509</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0471442509</sup></sup>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
 * [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0072424430</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0072424430</sup></sup>
 
 ---
 
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
-<div align="right"><sub><sup>ISBN: 978-0750653008</sup></sub></div>
+<br/><sup><sup>ISBN: 978-0750653008</sup></sup>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [BAJA Student India Online Training Series](https://www.youtube.com/playlist?list=PLJRDa46CU8JLLiGpLtlhkMSMDjTVzW_1r)
 * [Altair HyperWorks Online Training series - Meshing, Analysis & Post-processing](https://www.youtube.com/playlist?list=PLJRDa46CU8JIraHKqVbX5K2-nImf1UMHQ)
 
+#### Simscale
+
 ### <a name="for-control"></a>For Control Engineering
 ###### MATLAB
 * [Control Tutorials for MATLAB and Simulink](http://ctms.engin.umich.edu/CTMS/index.php?aux=Home)
@@ -396,28 +398,44 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 #### CATIA
 [Student Edition](https://academy.3ds.com/en/software/catia-v5-student-edition) until Nov. 26th. *Promo code*: `CATIA4FREE17`
 
-#### <a name="#nx"></a>Siemens NX Unigraphics
+#### NX
+*Formely known as* Unigraphics.
 * [NX Resources](https://www.plm.automation.siemens.com/en/academic/resources/nx/index.shtml) `Siemens`
 
-#### <a name="#solidworks"></a>SolidWorks
+##### OpenSource
+#### FreeCAD
+Website: [http://www.openscad.org/](http://www.openscad.org/)
+*Geometric Kernel* [OpenCASCADE](https://github.com/tpaviot/oce)
 
-#### <a name="#autocad"></a>AutoCAD
+* [CadQuery Plugin for FreeCAD](https://github.com/jmwright/cadquery-freecad-module), "python based language for building parametric models" [[Wiki](https://github.com/jmwright/cadquery-freecad-module/wiki)]
+  * [CadQuery Documentation](http://dcowden.github.io/cadquery/)
 
-#### <a name="#blender"></a>Blender
+#### OpenSCAD
+Website: [http://www.openscad.org/](http://www.openscad.org/)
+Script based modeller
+*Geometric Kernel* [OpenCSG](http://opencsg.org/) + [CGAL](https://www.cgal.org/)
 
-#### <a name="#solidedge"></a>Siemens Solid Edge
+#### BRL-CAD
+Website: [http://brlcad.org/](http://brlcad.org/)
 
-#### <a name="#proe"></a>PTC PTC Creo (formerly known as Pro/ENGINEER)
+<details><summary>Coming Soon</summary><br/>
+<!-- Empty sections Bloat: move out when ready  -->
+#### SolidWorks
+#### Solid Edge
+#### Creo 
+*Formerly known as* Pro/ENGINEER.
+#### OnShape
+Cloud Based CAD
+Website: [https://www.onshape.com/](https://www.onshape.com/)
 
-#### <a name="#spaceclaim"></a>SpaceClaim
-
+#### SpaceClaim
+#### AutoCAD
+</details>
+<details><summary>Surface Modelling</summary><br/>
+#### Blender
+#### SketchUp
 #### <a name="#rhino"></a>Rhinoceros 3D
-
-#### <a name="#sketchup"></a>SketchUp
-
-#### <a name="#freecad"></a>FreeCAD
-
-#### <a name="#brlcad"></a>BRL-CAD
+</details>
 
 ---
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 ---
 
-<details open>
-<summary><h1>Table of Contents</h1></summary>
+Table of Contents
+-----------------
+<details open><summary>Hide</summary>
 
-***
 
 [Preamble](#preamble)
 

--- a/README.md
+++ b/README.md
@@ -408,29 +408,30 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [r/Lectures](https://www.reddit.com/r/lectures/)
 * [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things
 <details><summary>Other</summary><br/>
-* [r/Aerospace](https://www.reddit.com/r/aerospace/): Aerospace Engineering
-* [r/AskElectronics](https://www.reddit.com/r/AskElectronics/): CE/EE Q&A
-* [r/AskScience](https://www.reddit.com/r/AskScience/): No-nonsense science Q&A
-* [r/BioEngineering](https://www.reddit.com/r/BioEngineering/): Biological
-* [r/Biology](https://www.reddit.com/r/biology/)
-* [r/Biotech](https://www.reddit.com/r/biotech/): Biotechnology
-* [r/ChemE](https://www.reddit.com/r/chemicalengineering/): Chemical Engineering
-* [r/Chemistry](https://www.reddit.com/r/chemistry/)
-* [r/Coding](https://www.reddit.com/r/coding/)
-* [r/ComputerScience](https://www.reddit.com/r/ComputerScience/)
-* [r/Construction](https://www.reddit.com/r/construction/): Construction
-* [r/CSBooks](https://www.reddit.com/r/csbooks/): Computer Science
-* [r/ECE](https://www.reddit.com/r/ECE/): General EE & CE discussion
-* [r/ECEComponentExchange](https://www.reddit.com/r/ECEComponentExchange/): Parts swap
-* [r/EE](https://www.reddit.com/r/electricalengineering/): Electrical Engineering
-* [r/EEBooks](https://www.reddit.com/r/eebooks/): Electrical Engineering
-* [r/Electronics](https://www.reddit.com/r/electronics/)
-* [r/Math](https://www.reddit.com/r/math/)
-* [r/MathBooks](https://www.reddit.com/r/mathbooks/): Mathematics
-* [r/Physics](https://www.reddit.com/r/physics/)
-* [r/PhysicsBooks](https://www.reddit.com/r/physicsbooks/): Physics
-* [r/Programming](https://www.reddit.com/r/programming/)
-* [r/Science](https://www.reddit.com/r/science/)
+
+  * [r/Aerospace](https://www.reddit.com/r/aerospace/): Aerospace Engineering
+  * [r/AskElectronics](https://www.reddit.com/r/AskElectronics/): CE/EE Q&A
+  * [r/AskScience](https://www.reddit.com/r/AskScience/): No-nonsense science Q&A
+  * [r/BioEngineering](https://www.reddit.com/r/BioEngineering/): Biological
+  * [r/Biology](https://www.reddit.com/r/biology/)
+  * [r/Biotech](https://www.reddit.com/r/biotech/): Biotechnology
+  * [r/ChemE](https://www.reddit.com/r/chemicalengineering/): Chemical Engineering
+  * [r/Chemistry](https://www.reddit.com/r/chemistry/)
+  * [r/Coding](https://www.reddit.com/r/coding/)
+  * [r/ComputerScience](https://www.reddit.com/r/ComputerScience/)
+  * [r/Construction](https://www.reddit.com/r/construction/): Construction
+  * [r/CSBooks](https://www.reddit.com/r/csbooks/): Computer Science
+  * [r/ECE](https://www.reddit.com/r/ECE/): General EE & CE discussion
+  * [r/ECEComponentExchange](https://www.reddit.com/r/ECEComponentExchange/): Parts swap
+  * [r/EE](https://www.reddit.com/r/electricalengineering/): Electrical Engineering
+  * [r/EEBooks](https://www.reddit.com/r/eebooks/): Electrical Engineering
+  * [r/Electronics](https://www.reddit.com/r/electronics/)
+  * [r/Math](https://www.reddit.com/r/math/)
+  * [r/MathBooks](https://www.reddit.com/r/mathbooks/): Mathematics
+  * [r/Physics](https://www.reddit.com/r/physics/)
+  * [r/PhysicsBooks](https://www.reddit.com/r/physicsbooks/): Physics
+  * [r/Programming](https://www.reddit.com/r/programming/)
+  * [r/Science](https://www.reddit.com/r/science/)
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ I got inspiration from the countless awesome lists in github.
 * [Elements of Structures](https://www.edx.org/course/elements-structures-mitx-2-01x-1) `edX MIT`
 * [Mechanical Properties of Materials](https://www.mechanicalc.com/reference/material-properties)
 * [Mechanics of Materials](http://madhuvable.org/books-2/introduction/), by [M. Vable](http://pages.mtu.edu/~mavable/) (2009) `MTU.edu` 
+
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
+* Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen <sub><sup>ISBN: 978-0470694527</sup></sub> `Amazon`
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design

--- a/README.md
+++ b/README.md
@@ -146,9 +146,8 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="math"></a>Mathematics
 ### Calculus and Linear Algebra
 * [Calculus](https://ocw.mit.edu/resources/res-18-001-calculus-online-textbook-spring-2005/textbook/), by G. Strang. [Direct download](http://ocw.mit.edu/ans7870/resources/Strang/Edited/Calculus/Calculus.pdf) `MIT.edu` 
@@ -199,9 +198,8 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## Mechanics
 ### <a name="continuum"></a>Continuum Mechanics
 * [Introduction to the Mechanics of a Continuous Medium, L.E. Malvern](https://archive.org/details/in.ernet.dli.2015.140589) (1969) Copyright Expired `Archive.org`
@@ -290,9 +288,8 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
@@ -304,9 +301,8 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
-</div>
-
+<sup>[Back to Top](#toc)</sup> &Hat;
+</div
 ## <a name="fea"></a>Finite Element Analysis
 * [Finite Element Procedures](http://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf), by [K.J. Bathe](http://meche.mit.edu/people/faculty/kjb@mit.edu) (2014) `MIT.edu`
 * [Introduction to the Finite Element Method](http://hyfem.com/HyFem/fem.pdf), by C.S. Jog
@@ -324,9 +320,8 @@ I got inspiration from the countless awesome lists in github.
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="software"></a>Software Packages
 ### <a name="for-fea"></a>For Finite Element Analysis
 * [Code_Aster](https://www.code-aster.org/)
@@ -422,9 +417,8 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="subreddits"></a> SubReddits Related to Mechanical Engineering
 * [r/AskEngineers](https://www.reddit.com/r/AskEngineers/): Non-school Q&A
 * [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
@@ -473,9 +467,8 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="publication"></a>Top Publication Venues for Different Fields
 
 ### Journals
@@ -494,9 +487,8 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="competition"></a>Competitions
 ### SAE Competitions
 
@@ -523,9 +515,8 @@ Misc
 ---
 <div align="right">
 
-<sup>[Back to Top](#top)</sup> &Hat;
+<sup>[Back to Top](#toc)</sup> &Hat;
 </div>
-
 ## <a name="certification"></a>Qualifying/Certification Examinations
 Qualifying examinations are a kind of certification to engineers - PE in USA, GATE in India
 

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ I got inspiration from the countless awesome lists in github.
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* Incropera, Frank P., DeWitt, David P.  *
-[Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. [ISBN: 978-0471386506] `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. ISBN: 978-0471386506 `Amazon`
+
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ I got inspiration from the countless awesome lists in github.
 * [507 Mechanical Movements](http://507movements.com/), animated movements
 * [Animated Engines](http://www.animatedengines.com/), animated engines
 * [thang010146](https://www.youtube.com/user/thang010146/videos), 2100+ animated mechanisms (downloadable) `youtube`
+* [DMG Lib, Digital Mechanism and Gear Library](http://www.dmg-lib.org/dmglib/main/portal.jsp)
 
 #### Patents
 * [Google Patents](https://www.google.com/patents/)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ I got inspiration from the countless awesome lists in github.
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 * [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
-<br/><sup><sup>ISBN: 978-0470694527</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0470694527</sup></sup>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -257,15 +257,15 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
 * [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
-<br/><sup><sup>ISBN: 978-0471274711</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0471274711</sup></sup>
 * [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
-<br/><sup><sup>ISBN: 978-0073398174</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0073398174</sup></sup>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
 * [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
-<br/><sup><sup>ISBN: 978-0471386506</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0471386506</sup></sup>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
@@ -273,19 +273,19 @@ I got inspiration from the countless awesome lists in github.
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
 * [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
-<br/><sup><sup>ISBN: 978-0471442509</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0471442509</sup></sup>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
 * [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
-<br/><sup><sup>ISBN: 978-0072424430</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0072424430</sup></sup>
 
 ---
 
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
-<br/><sup><sup>ISBN: 978-0750653008</sup></sup>
+&emsp;&bull; <sup><sup>ISBN: 978-0750653008</sup></sup>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 ---
 
-Table of Contents
+<details open>
+<summary>Table of Contents</summary>
 -----------------
 
 [Preamble](#preamble)
@@ -77,6 +78,7 @@ Table of Contents
 [Competitions](#competition)
 
 [Qualifying/Certification Examinations](#certification)
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ I got inspiration from the countless awesome lists in github.
 * [ScarbsTech](http://scarbsf1.com/), everything technical in F1
 * [GlobalSpec](http://insights.globalspec.com/)
 * [Hackaday](https://hackaday.com/)
+* [Plastics Engineering Blog](https://plasticsengineeringblog.com/)
 
 ---
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ I got inspiration from the countless awesome lists in github.
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
-* [Mechanisms/Machines](https://archive.org/details/MechanismsMachines), by L. Teel (1972) `Archive.org`
 * [Shigley's Mechanical Engineering Design](https://www.amazon.com/Shigleys-Mechanical-Engineering-Design-McGraw-Hill-ebook/dp/B00HZ3B1KI/ref=sr_1_2), by R.G.Budynas and J.K. Nisbett (2014) `Amazon`
+* [Introduction to Mechanisms](https://www.cs.cmu.edu/%7Erapidproto/mechanisms/tablecontents.html),  by Yi Zhang with S. Finger, S. Behrens. `CMU.edu`
+* [Mechanisms/Machines](https://archive.org/details/MechanismsMachines), by L. Teel (1972) `Archive.org`
 
 ### Control Engineering
 * [Modern Control Engineering](https://www.amazon.com/Modern-Control-Engineering-Katsuhiko-Ogata/dp/0136156738/ref=sr_1_cc_4), by K. Ogata (2009) `Amazon`

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ I got inspiration from the countless awesome lists in github.
 * [MATLAB Toolbox tutorials](http://www.tech.plym.ac.uk/spmc/links/matlab/matlab_toolbox.html)
 * [Control Tutorials for MATLAB and Simulink](http://ctms.engin.umich.edu/CTMS/index.php?aux=Home)
 * [A Brief Introduction to Engineering Computation with MATLAB](https://open.bccampus.ca/find-open-textbooks/?uuid=e12e3911-8a06-497e-b8c9-99e347092af0&contributor=&keyword=&subject=) `BCcampus.ca`
+* [Stuart’s MATLAB Videos](https://blogs.mathworks.com/videos/) (Blog) `MathWorks.com`
 
 ### <a name="r"></a>R (statistics)
 * [Intro to R for data science](https://www.edx.org/course/introduction-r-data-science-microsoft-dat204x-0) `edX Microsoft`

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ I got inspiration from the countless awesome lists in github.
 ---
 
 ## <a name="fea"></a>Finite Element Analysis
-* [Finite Element Procedures](http://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf), by KJ Bathe (2014) `MIT.edu`
+* [Finite Element Procedures](http://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf), by [K.J. Bathe](http://meche.mit.edu/people/faculty/kjb@mit.edu) (2014) `MIT.edu`
 * [Introduction to the Finite Element Method](http://hyfem.com/HyFem/fem.pdf), by C.S. Jog
 
 ###### Good Reads

--- a/README.md
+++ b/README.md
@@ -251,24 +251,24 @@ I got inspiration from the countless awesome lists in github.
 * [NASA's Introductory Thermodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/thermo.html) `NASA`
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
-* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. ISBN: 978-0471274711 `Amazon`
-* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. ISBN: 978-0073398174 `Amazon`
+* [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. <sub><sup>ISBN: 978-0471274711/sup></sub> `Amazon`
+* [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. <sub><sup>ISBN: 978-0073398174/sup></sub> `Amazon`
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
-* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <sub>ISBN: 978-0471386506</sub> `Amazon`
+* [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. <sub><sup>ISBN: 978-0471386506</sup></sub> `Amazon`
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
 * [MIT OpenCourseWare: Fluid Dynamics](https://ocw.mit.edu/courses/mechanical-engineering/2-06-fluid-dynamics-spring-2013/) `MIT.edu`
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
-* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. ISBN: 978-0471442509 `Amazon`
+* [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. <sub><sup>ISBN: 978-0471442509/sup></sub> `Amazon`
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
-* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  ISBN: 978-0072424430 `Amazon`
+* [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson.  <sub><sup>ISBN: 978-0072424430/sup></sub> `Amazon`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ I got inspiration from the countless awesome lists in github.
 ## Manufacturing
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 
+* [Geometric and Solid Modeling](https://www.cs.purdue.edu/homes/cmh/distribution/books/geo.html), by C.M. Hoffman (1992) *Out of Print* `Purdue.edu`
 
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`

--- a/README.md
+++ b/README.md
@@ -423,8 +423,9 @@ Script based modeller
 #### BRL-CAD
 >Website: [http://brlcad.org/](http://brlcad.org/)
 
-<details><summary>Coming Soon</summary>
+<details><summary><b>Coming Soon</b></summary>
 <!-- Empty sections Bloat: move out when ready  -->
+
 #### SolidWorks
 
 #### Solid Edge
@@ -440,7 +441,8 @@ Website: [https://www.onshape.com/](https://www.onshape.com/)
 
 #### AutoCAD
 </details>
-<details><summary>Surface Modelling</summary>
+<details><summary><b>Surface Modelling</b></summary>
+
 #### Blender
 
 #### SketchUp

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Licensed under [GNU General Public License v3.0](../master/LICENSE.MD)
 
 <a name="toc"></a>Table of Contents
 -----------------
-<details open><summary>Hide/Show</summary><br/>
+<details open><summary><sup>Hide/Show</sup></summary><br/>
 
 [Preamble](#preamble)
 

--- a/README.md
+++ b/README.md
@@ -395,14 +395,14 @@ Hyperworks is a complete commercial suite of Preprocessing, Solving, and Postpro
 * [r/AskEngineers](https://www.reddit.com/r/AskEngineers/): Non-school Q&A
 * [r/CAD](https://www.reddit.com/r/CAD/): Computer Aided Design
 * [r/CFD](https://www.reddit.com/r/CFD/): Computational Fluid Dynamics
-* [r/Engineering Fields](https://www.reddit.com/r/engineering/): About all things related to engineering
+* [r/Engineering](https://www.reddit.com/r/engineering/): About all things related to engineering
 * [r/EngineeringStudents](https://www.reddit.com/r/EngineeringStudents/): For wee engineerlings
 * [r/FEA](https://www.reddit.com/r/fea/): Finite Element Analysis
 * [r/FluidMechanics](https://www.reddit.com/r/FluidMechanics/)
-* [r/Civil Engineering](https://www.reddit.com/r/civilengineering/): Civil Engineering
+* [r/CivilEngineering](https://www.reddit.com/r/civilengineering/): Civil Engineering
 * [r/Manufacturing](https://www.reddit.com/r/Manufacturing/): Manufacturing Industry
 * [r/Materials](https://www.reddit.com/r/materials/): Materials Engineering
-* [r/MechE](https://www.reddit.com/r/mechanicalengineering/): Mechanical Engineering
+* [r/MechanicalEngineering](https://www.reddit.com/r/mechanicalengineering/): Mechanical Engineering
 Misc
 * [r/EngineeringPorn](https://www.reddit.com/r/EngineeringPorn/): porn for engineers (*safe for work*)
 * [r/Mechanical_gifs](https://www.reddit.com/r/mechanical_gifs/): perfect loops of mechanical things

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ I got inspiration from the countless awesome lists in github.
 
 ## Manufacturing
 ### Sheet Metal Forming
-* [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak J.L. Duncan and S.J. Hu (2002) <sub><sup>ISBN: 978-0750653008</sup></sub> `Amazon`
+* [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) <sub><sup>ISBN: 978-0750653008</sup></sub> `Amazon`
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![Banner Image](../master/img/open-end-wrench-2452245_1920.jpg)
 
+<div align="right">
+
+|&bigstar; **CTRL+D**|
+|---|
+</div>
+
 _So many free resources are available for computer science students and I am jealous. Therefore, I started making this list for mechanical engineering students. This section contains some overview resources, rules and regulations, and advice._
 
 Check the [contributions guideline](../master/contributions.md)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ I got inspiration from the countless awesome lists in github.
 * [A Mathematical Introduction to Robotic Manipulation](http://www.cds.caltech.edu/~murray/mlswiki/?title=First_edition) `Caltech.edu`
 
 ---
+<div align="right">
+
+<sup>[Back to Top](#toc)</sup> &Hat;
+</div>
 
 ## <a name="thermo"></a>Thermal Engineering
 ### Thermodynamics

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ I got inspiration from the countless awesome lists in github.
 ### Plasticity
 * [The Mathematical Theory of Plasticity](https://archive.org/details/in.ernet.dli.2015.84513), by R. Hill (1950) `Archive.org`
 * [Computational Methods for Plasticity](https://www.amazon.com/Computational-Methods-Plasticity-Theory-Applications/dp/0470694521/), by E.A. de Souza Neto, D. Peric & D.R.J. Owen  `Amazon`
-<br/><sup><sup>ISBN: 978-0470694527</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0470694527</sup></sub></div>
 
 ## <a name="machine"></a>Theory of Machines
 ### Mechanism Design
@@ -257,15 +257,15 @@ I got inspiration from the countless awesome lists in github.
 * [MIT OpenCourseWare: Thermodynamics & Kinematics Lecture Series](https://ocw.mit.edu/courses/chemistry/5-60-thermodynamics-kinetics-spring-2008/) `MIT.edu`
 * [Wikibooks: Engineering Thermodynamics](https://en.wikibooks.org/wiki/Engineering_Thermodynamics) `Wikibooks`
 * [Fundamentals of Engineering Thermodynamics](https://www.amazon.com/Fundamentals-Engineering-Thermodynamics-Michael-Moran/dp/0471787353/), by M.J. Moran & H.N. Shapiro. `Amazon`
-<br/><sup><sup>ISBN: 978-0471274711</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0471274711</sup></sub></div>
 * [Thermodynamics: An Engineering Approach](https://www.amazon.com/Thermodynamics-Engineering-Yunus-Cengel-Dr/dp/0073398179/), by Y.A. Cengel & M.A. Boles. `Amazon`
-<br/><sup><sup>ISBN: 978-0073398174</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0073398174</sup></sub></div>
 
 ### Heat Transfer
 * [MIT OpenCourseWare: Introduction to Heat Transfer](https://ocw.mit.edu/courses/mechanical-engineering/2-051-introduction-to-heat-transfer-fall-2015/) `MIT.edu`
 * [Wikibooks: Heat Transfer](https://en.wikibooks.org/wiki/Heat_Transfer) `Wikibooks`
 * [Fundamentals of Heat and Mass Transfer](https://www.amazon.com/Fundamentals-Heat-Mass-Transfer-5th/dp/0471386502/) , by F.P. Incropera & D.P. DeWitt. `Amazon`
-<br/><sup><sup>ISBN: 978-0471386506</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0471386506</sup></sub></div>
 
 ### Fluid Mechanics
 * [NASA's Basic Fluid Mechanics Notes](https://www.grc.nasa.gov/www/k-12/airplane/mass.html) `NASA`
@@ -273,19 +273,19 @@ I got inspiration from the countless awesome lists in github.
 * [Wikibooks: Fluid Mechanics](https://en.wikibooks.org/wiki/Fluid_Mechanics) `Wikibooks`
 * Thermophysical properties of water and steam: [International Association for the Properties of Water and Steam](http://iapws.org/relguide/IAPWS-95.html)
 * [Fundamentals of Fluid Mechanics](https://www.amazon.com/Fundamentals-Fluid-Mechanics-Bruce-Munson/dp/047144250X), by B.R. Munson, D.R. Young & T.H. Okiishi. `Amazon`
-<br/><sup><sup>ISBN: 978-0471442509</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0471442509</sup></sub></div>
 
 ### Gas Dynamics
 * [NASA's Compressible Fluids/Aerodynamics Notes](https://www.grc.nasa.gov/www/k-12/airplane/shortc.html) `NASA`
 * [Modern Compressible Flow: With Historical Perspective](https://www.amazon.com/Modern-Compressible-Flow-Historical-Perspective/dp/0071241361/), by J.D. Anderson. `Amazon`
-<br/><sup><sup>ISBN: 978-0072424430</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0072424430</sup></sub></div>
 
 ---
 
 ## Manufacturing
 ### Sheet Metal Forming
 * [Mechanics of Sheet Metal Forming](https://www.amazon.com/Mechanics-Sheet-Metal-Forming-Second/dp/0750653000), by Z. Marciniak, J.L. Duncan and S.J. Hu (2002) `Amazon`
-<br/><sup><sup>ISBN: 978-0750653008</sup></sup>
+<div align="right"><sub><sup>ISBN: 978-0750653008</sup></sub></div>
 * [SheetMetal.me](http://sheetmetal.me/)
 ### CAD/CAM Theory
 * [Shape Interrogation for CAD and Manufacturing](http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/), by N.M. Patrikalakis, T. Maekawa & W. Cho (2009). `MIT.edu` ([Amazon](https://www.amazon.com/exec/obidos/ASIN/3540424547/qid=1014647930/sr=8-1/ref=sr_)) 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ![Banner Image](../master/img/open-end-wrench-2452245_1920.jpg)
 
-<div align="right">
-
-|&bigstar; **Ctrl+D**|
-|---|
-</div>
-
 _So many free resources are available for computer science students and I am jealous. Therefore, I started making this list for mechanical engineering students. This section contains some overview resources, rules and regulations, and advice._
 
 Check the [contributions guideline](../master/contributions.md)


### PR DESCRIPTION
Closes #29
Lots of commits, but they are mostly undo/reverts/various errors.

I used @pwab 's suggestion and added a collapsible ToC and "Back to Top" links

Other stuff:
* Plasticity section
* CAD software update
* CAD/CAM section update (theory/books/tutorials/techniques)

A note on ISBN style: 
* book title, etc... &emsp;&bull; <sub><sup>ISBN: 978-1439802472</sup></sub>

I personally like it, not much to say; if you dislike it, I can revert it back.
The html is this:
````html
&emsp;&bull; <sub><sup>ISBN: 978-1439802472</sup></sub>
````

To sum it up, the list needs a *style's guideline*.