### PR TITLE
Add EngineeringPaper.xyz to Online Calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ I got inspiration from the countless awesome lists in github.
 
 #### <a name="calculator"></a>Online Calculators
 * [Desmos](https://www.desmos.com/calculator), online graphing calculator
+* [EngineeringPaper.xyz](https://engineeringpaper.xyz), engineering calculator with units support, plotting, and equation solving
 * [fxSolver](https://www.fxsolver.com/), solver for engineering and scientific equations
 * [MechaniCalc](https://mechanicalc.com/), mechanical calculator with extensive documentation
 * [WolframAlpha](https://www.wolframalpha.com/)


### PR DESCRIPTION
EngineeringPaper.xyz is a free web app for engineering calculations that has features similar to Mathcad. This update adds it to the Online Calculator section.